### PR TITLE
fix(scraper): remove non-existent updated_at column reference

### DIFF
--- a/services/scraper/src/database.ts
+++ b/services/scraper/src/database.ts
@@ -85,8 +85,7 @@ class ScraperDatabase {
         name = EXCLUDED.name,
         url = EXCLUDED.url,
         description = EXCLUDED.description,
-        is_active = EXCLUDED.is_active,
-        updated_at = CURRENT_TIMESTAMP
+        is_active = EXCLUDED.is_active
       RETURNING id
     `;
     


### PR DESCRIPTION
- Remove updated_at column from sources table upsert query
- The sources table schema doesn't have an updated_at column
- This was causing Fox News scraping to fail during source setup
- CNN worked because it didn't trigger the UPDATE part of the upsert
- Both sources should now work correctly