### PR TITLE
refactor(scraper): streamline job status handling and enhance logging…

### DIFF
--- a/services/scraper/src/types.ts
+++ b/services/scraper/src/types.ts
@@ -7,11 +7,14 @@ export interface ScrapingJob {
   totalArticlesScraped: number;
   totalErrors: number;
   triggeredAt: string;
-  startedAt?: string;
   completedAt?: string;
-  duration?: number;      // seconds
-  progress?: number;      // 0-100
-  currentSource?: string; // Currently processing
+  jobLogs?: string;
+  createdAt: string;
+  updatedAt: string;
+  // Calculated fields (not in database)
+  duration?: number;      // calculated from completedAt - triggeredAt
+  progress?: number;      // derived from logs
+  currentSource?: string; // derived from latest log
 }
 
 export type JobStatus = ScrapingJob['status'];

--- a/services/ui/app/scraper/types.ts
+++ b/services/ui/app/scraper/types.ts
@@ -2,16 +2,19 @@
 export interface ScrapingJob {
   id: string;
   status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
-  sourcesRequested?: string[];
+  sourcesRequested: string[];
   articlesPerSource: number;
   totalArticlesScraped: number;
   totalErrors: number;
   triggeredAt: string;
-  startedAt?: string;
   completedAt?: string;
-  duration?: number;      // seconds
-  progress?: number;      // 0-100
-  currentSource?: string; // Currently processing
+  jobLogs?: string;
+  createdAt: string;
+  updatedAt: string;
+  // Calculated fields (not in database)
+  duration?: number;      // calculated from completedAt - triggeredAt
+  progress?: number;      // derived from logs
+  currentSource?: string; // derived from latest log
 }
 
 export type JobStatus = ScrapingJob['status'];


### PR DESCRIPTION
… (#40)

- Removed the `started_at` logic from the job status update function, establishing that jobs start when created, not when their status changes to 'running'.
- Updated the `updateJobProgress` function to log progress details, including current source and percentage, while ensuring only existing fields are updated.
- Enhanced the `getJob` function to include calculated fields and retrieve the latest progress from logs, improving job tracking and data accuracy.
- Adjusted the `ScrapingJob` interface to reflect changes in job logging and tracking, ensuring consistency across the application.

This update simplifies job management and enhances the logging capabilities of the scraper service, aligning with the project's focus on clarity and efficiency.